### PR TITLE
Add link to task name in the session table that takes you to the desired show task page

### DIFF
--- a/resources/js/components/IndexSessionTable.vue
+++ b/resources/js/components/IndexSessionTable.vue
@@ -56,9 +56,11 @@
                         <td class="pl-4">
                             <div class="overflow-auto h-full whitespace-no-wrap">
                                 <div v-if="session.task_id">
-                                    <i class="fas fa-check-square text-gray-400 mr-2"></i>
-                                    <span class="font-semibold"> {{ taskPrefix(session.task_name) }} </span>
-                                    <span class="text-base"> {{ taskSuffix(session.task_name) }} </span>
+                                    <inertia-link  class="no-underline hover:opacity-50 opacity-100" :href="route('task.show', session.task_id)">
+                                        <i class="fas fa-check-square text-gray-400 mr-2"></i>
+                                        <span class="font-semibold"> {{ taskPrefix(session.task_name) }} </span>
+                                        <span class="text-base"> {{ taskSuffix(session.task_name) }} </span>
+                                    </inertia-link>
                                 </div>
                                 <div class="flex items-center text-gray-500">
                                     <div class="w-32">
@@ -419,7 +421,7 @@
             },
             taskSuffix(name) {
                 let suffix = name.split(':')[1];
-                
+
                 return suffix ? ':' + suffix : '';
             },
         },


### PR DESCRIPTION
Issue https://github.com/YakTrack/YakTrack/issues/132

This PR will add a link to the task name in the sessions table that when clicked will take you to the show task page for that task.

Showing name as link
![image](https://user-images.githubusercontent.com/33623309/95783007-e0d54d80-0cc8-11eb-8965-72ac91ba1791.png)

On hover
![image](https://user-images.githubusercontent.com/33623309/95783041-ee8ad300-0cc8-11eb-99de-2222dfa4b983.png)

After click
![image](https://user-images.githubusercontent.com/33623309/95783072-fb0f2b80-0cc8-11eb-862a-8ddf22818933.png)
