### PR TITLE
Fix failing feature test due to apostrophe in project name. 

### DIFF
--- a/resources/js/Pages/Project/Show.vue
+++ b/resources/js/Pages/Project/Show.vue
@@ -8,7 +8,6 @@
             ]" ></breadcrumbs>
         </template>
         <div class="card">
-          STEVE
             <h1 class="font-medium text-gray-dark"> {{ project.name }} </h1>
             <div class="p4 mt-4">
                 <i class="fa fa-user text-2xl text-gray-300 mr-2"></i>

--- a/resources/js/Pages/Project/Show.vue
+++ b/resources/js/Pages/Project/Show.vue
@@ -8,6 +8,7 @@
             ]" ></breadcrumbs>
         </template>
         <div class="card">
+          STEVE
             <h1 class="font-medium text-gray-dark"> {{ project.name }} </h1>
             <div class="p4 mt-4">
                 <i class="fa fa-user text-2xl text-gray-300 mr-2"></i>

--- a/tests/Feature/Project/ShowProjectTest.php
+++ b/tests/Feature/Project/ShowProjectTest.php
@@ -21,7 +21,27 @@ class ShowProjectTest extends TestCase
 
         $response->assertSuccessful();
 
-        $response->assertSee($project->name);
+        // escape the apostrophe in the same manner as blade is
+        $response->assertSee(e($project->name));
+
+        $response->assertSee($project->description);
+        $response->assertSee($project->client->name);
+    }
+
+    /** @test */
+    public function a_logged_in_user_can_view_details_of_a_project_with_an_apostrophe_in_the_name()
+    {
+        $project = factory(Project::class)->create(['name' => 'Steve\'s Test Project']);
+
+        $this->actingAsUser();
+
+        $response = $this->get(route('project.show', ['project' => $project]));
+
+        $response->assertSuccessful();
+
+        // escape the apostrophe in the same manner as blade is
+        $response->assertSee(e($project->name));
+
         $response->assertSee($project->description);
         $response->assertSee($project->client->name);
     }


### PR DESCRIPTION
Issue https://github.com/YakTrack/YakTrack/issues/117

- Fix failing feature test due to apostrophe in project name.
- Add feature test to specifically test a project with an apostrophe in the name.

Show Project Test Results
![image](https://user-images.githubusercontent.com/33623309/95785333-7672dc00-0ccd-11eb-92e6-0b7fe3b90b05.png)
