### PR TITLE
Fixed position of close button on modals

### DIFF
--- a/resources/js/Shared/Dropdown.vue
+++ b/resources/js/Shared/Dropdown.vue
@@ -7,7 +7,7 @@
             <span> {{ label || 'Actions' }} </span>
             <i class="fas fa-caret-down"></i>
         </button>
-        <div class="rounded shadow-md mt-2 absolute mt-12 -ml-1 mb-12 pin-t pin-l min-w-full bg-white text-left" :class="isOpen || 'dropdown-closed'">
+        <div class="rounded shadow-md mt-2 absolute mt-12 -ml-1 mb-12 top-0 left-0 min-w-full bg-white text-left" :class="isOpen || 'dropdown-closed'">
             <ul class="list-reset w-max-content min-w-full p-1">
                 <li v-for="option in options" :key="option.name" class="clickable"> 
                     <a

--- a/resources/js/Shared/HeaderNav.vue
+++ b/resources/js/Shared/HeaderNav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bg-white fixed w-full flex border-b border-gray-300 pin-t pin-x z-40 h-16 items-center shadow">
+    <div class="bg-white fixed w-full flex border-b border-gray-300 top-0 inset-x-0 z-40 h-16 items-center shadow">
         <nav class="flex justify-between flex-wrap bg-white pl-5 py-3 pr-0 h-16 w-full mx-auto">
             <div class="flex items-left flex-no-shrink text-white m-1">
                 <logo></logo>

--- a/resources/js/components/Modal.vue
+++ b/resources/js/components/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="modalIsOpen" @click.self="toggleModal" class="modal opacity-100 pin-x pin-b fixed w-full h-full top-0 left-0 flex items-center justify-center z-50">
+    <div v-if="modalIsOpen" @click.self="toggleModal" class="modal opacity-100 inset-x-0 bottom-0 fixed w-full h-full top-0 left-0 flex items-center justify-center z-50">
         <div class="modal-overlay fixed w-full h-full bg-gray-900 opacity-50 z-50"></div>
         <div class="modal-container bg-white p-4 w-11/12 md:max-w-md mx-auto rounded shadow-lg z-50 overflow-y-auto opacity-100 relative">
             <slot :payload="payload"></slot>
@@ -11,7 +11,7 @@
                     {{ primaryButtonText }}
                 </button>
             </div>
-            <span @click="toggleModal" class="absolute pin-t pin-r pt-4 px-4">
+            <span @click="toggleModal" class="absolute top-0 right-0 pt-4 px-4">
                 <svg class="h-12 w-12 text-gray-500 hover:text-gray-900" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
             </span>
         </div>


### PR DESCRIPTION
Addresses issue https://github.com/YakTrack/YakTrack/issues/121

- fixed the position of the close button on modals

This was due to using a class that had been removed from tailwind.

- updated the other uses of these removed classes to the newer version throughout the codebase.

Before

![image](https://user-images.githubusercontent.com/33623309/137592350-b030539c-8674-4b20-92eb-248f1133705e.png)

After

![image](https://user-images.githubusercontent.com/33623309/137592318-7043ff65-6fb2-432d-a19f-e94c59fc350c.png)
