### PR TITLE
Redirect to sessions view on successful linking of invoice to sessions via modal

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -80,9 +80,20 @@ class InvoiceController extends Controller
 
         $invoice->sessions()->saveMany(Session::findMany($request->sessions));
 
+        $successMessage = 'Invoice '.$invoice->number.' updated.';
+
+        if (
+            $request->has('redirectToSessionsScreen') &&
+            $request->redirectToSessionsScreen
+        ) {
+            return redirect()
+                ->route('session.index')
+                ->with('success', $successMessage);
+        }
+
         return redirect()
             ->route('invoice.index')
-            ->with('success', 'Invoice '.$invoice->number.' updated.');
+            ->with('success', $successMessage);
     }
 
     public function show(Invoice $invoice)

--- a/resources/js/Shared/Messages.vue
+++ b/resources/js/Shared/Messages.vue
@@ -20,28 +20,40 @@
             }
         },
         created() {
-            [
-                {
-                    type: 'success',
-                    message: this.$page.props.flash.success,
-                },
-                {
-                    type: 'error',
-                    message: this.$page.props.flash.error,
-                },
-            ].filter(alert => alert.message)
-            .forEach(alert => this.alerts.push(alert));
-
-            Object.keys(this.$page.props.errors).forEach(key => {
-                this.alerts.push({
-                    type: 'error',
-                    message: this.$page.errors[key].join("\n"),
-                });
-            })
+            this.showFlashMessages();
 
             window.events.$on('notify', (notification) => {
                 this.alerts.push(notification);
             });  
         },
+        methods: {
+            showFlashMessages() {
+                [
+                    {
+                        type: 'success',
+                        message: this.$page.props.flash.success,
+                    },
+                    {
+                        type: 'error',
+                        message: this.$page.props.flash.error,
+                    },
+                ].filter(alert => alert.message)
+                .forEach(alert => this.alerts.push(alert));
+
+                Object.keys(this.$page.props.errors).forEach(key => {
+                    this.alerts.push({
+                        type: 'error',
+                        message: this.$page.errors[key].join("\n"),
+                    });
+                })
+            }
+        },
+        watch: {
+            '$page.props.flash': {
+                handler() {
+                    this.showFlashMessages();
+                },
+            }
+        }
     }
 </script>

--- a/resources/js/components/IndexSessionTable.vue
+++ b/resources/js/components/IndexSessionTable.vue
@@ -388,8 +388,11 @@
                 });
             },
             linkSelectedSessionsToInvoice() {
+                events.$emit('sessions.linked-to-invoice');
+
                 this.$inertia.patch(route('invoice.update', this.selectedInvoiceId), {
                     sessions: this.selectedSessionIds,
+                    redirectToSessionsScreen: true,
                 });
             },
             selectInvoice(invoiceId) {


### PR DESCRIPTION
Addresses issue https://github.com/YakTrack/YakTrack/issues/120

I've had to make a change to 'watch' the flash messages because I couldn't get the flash success message to display without doing so.

I believe this is down to us not leaving the session screen now so we need to watch for the change rather than the (messages component being created again?), previously it worked fine as we redirected to the invoices screen.