### PR TITLE
Fix issue where sessions without a task attached could not be continued

### DIFF
--- a/resources/js/components/IndexSessionTable.vue
+++ b/resources/js/components/IndexSessionTable.vue
@@ -103,7 +103,11 @@
                                 <button v-if="session.isRunning" class="text-gray-600 btn hover:text-red-600 hover:bg-red-100" @click="stopSession(session)">
                                     <i class="fa fa-stop fa-xs"></i>
                                 </button>
-                                <button v-if="session.task_id && !session.isRunning" class="text-gray-600 btn hover:text-green-600 hover:bg-green-100" @click="continueSession(session)">
+                                <button
+                                    v-if="!session.isRunning"
+                                    class="text-gray-600 btn hover:text-green-600 hover:bg-green-100"
+                                    @click="continueSession(session)"
+                                >
                                     <i class="fas fa-play fa-xs"></i>
                                 </button>
                                 <inertia-link


### PR DESCRIPTION
- Previously it didn't make sense to continue a session with no task attached, because there was nothing to 'continue', it was just a blank session
- Now we have other information which can be attached to the session such as the sprint, or the invoice which is automatically attached to the new session when an old session is 'continued' so it makes sense to allow this

- Fixes #187