### PR TITLE
Add session before / after existing sessions

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -10,6 +10,7 @@ use App\Models\SessionCategory;
 use App\Models\Sprint;
 use App\Models\Task;
 use App\Models\ThirdPartyApplication;
+use App\Services\SessionAdjacencyResolver;
 use App\Services\SessionDateLockService;
 use App\Services\SessionSplitter;
 use App\Support\DateTimeFormatter;
@@ -24,15 +25,18 @@ class SessionController extends Controller
     private IndexSessionQuery $indexSessionQuery;
     private DateTimeFormatter $dateTimeFormatter;
     private SessionDateLockService $sessionDateLockService;
+    private SessionAdjacencyResolver $sessionAdjacencyResolver;
 
     public function __construct(
         DateTimeFormatter $dateTimeFormatter,
         IndexSessionQuery $indexSessionQuery,
         SessionDateLockService $sessionDateLockService,
+        SessionAdjacencyResolver $sessionAdjacencyResolver,
     ) {
         $this->indexSessionQuery = $indexSessionQuery;
         $this->dateTimeFormatter = $dateTimeFormatter;
         $this->sessionDateLockService = $sessionDateLockService;
+        $this->sessionAdjacencyResolver = $sessionAdjacencyResolver;
     }
 
     public function index(): RedirectResponse|Response
@@ -62,12 +66,20 @@ class SessionController extends Controller
             ->lockedDatesForUser(auth()->user())
             ->flip();
 
-        /** @var \Illuminate\Support\Collection<int, array{date: string, is_locked: bool, sessions: \Illuminate\Support\Collection<int, \App\Models\Session>, totalDurationForHumans: string}> $days */
-        $days = $groupedSessions->map(function (\Illuminate\Support\Collection $sessionsOnDay, string $date) use ($lockedDates): array {
+        $adjacency = $this->sessionAdjacencyResolver->resolve(
+            $sessions instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator
+                ? $sessions->getCollection()
+                : $sessions
+        );
+
+        /** @var \Illuminate\Support\Collection<int, array{date: string, is_locked: bool, sessions: \Illuminate\Support\Collection<int, array<string, mixed>>, totalDurationForHumans: string}> $days */
+        $days = $groupedSessions->map(function (\Illuminate\Support\Collection $sessionsOnDay, string $date) use ($lockedDates, $adjacency): array {
             return [
                 'date'                   => $date,
                 'is_locked'              => $lockedDates->has($date),
-                'sessions'               => $sessionsOnDay,
+                'sessions'               => $sessionsOnDay->map(function (Session $session) use ($adjacency): array {
+                    return array_merge($session->toArray(), $adjacency[$session->id] ?? []);
+                })->values(),
                 'totalDurationForHumans' => $sessionsOnDay->totalDurationForHumans(),
             ];
         })->values();
@@ -76,6 +88,7 @@ class SessionController extends Controller
             'invoices'               => Invoice::all(),
             'thirdPartyApplications' => ThirdPartyApplication::all(),
             'sprints'                => Sprint::with('projects.client')->orderBy('id', 'desc')->get(),
+            'sessionCategories'      => SessionCategory::query()->select(['id', 'name'])->get(),
             'tasks'                  => $this->sessionFormTasks(),
             'days'                   => $days,
             'total'                  => (int) $total = Session::forFocusedClient($focusedClientId)->count(),

--- a/app/Services/SessionAdjacencyResolver.php
+++ b/app/Services/SessionAdjacencyResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Session;
+use App\Support\DateTimeFormatter;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class SessionAdjacencyResolver
+{
+    public function __construct(private DateTimeFormatter $dateTimeFormatter)
+    {
+    }
+
+    /**
+     * Resolve, for each session, whether a session may be added immediately
+     * before or after it, along with the default times such a session would
+     * take. A session may be added on a given side when no existing session
+     * is touching it on that side.
+     *
+     * @param Collection<int, Session> $sessions
+     *
+     * @return array<int, array{can_add_session_before: bool, can_add_session_after: bool, add_before_started_at: string, add_before_ended_at: string, add_after_started_at: string|null, add_after_ended_at: string|null}>
+     */
+    public function resolve(Collection $sessions): array
+    {
+        $map = [];
+
+        foreach ($sessions as $session) {
+            $map[$session->id] = $this->resolveForSession($session, $sessions);
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param Collection<int, Session> $sessions
+     *
+     * @return array{can_add_session_before: bool, can_add_session_after: bool, add_before_started_at: string, add_before_ended_at: string, add_after_started_at: string|null, add_after_ended_at: string|null}
+     */
+    private function resolveForSession(Session $session, Collection $sessions): array
+    {
+        $others = $sessions->reject(fn (Session $other): bool => $other->id === $session->id);
+
+        $hasSessionImmediatelyBefore = $others->contains(
+            fn (Session $other): bool => $other->ended_at !== null && $other->ended_at->equalTo($session->started_at)
+        );
+
+        $hasSessionImmediatelyAfter = $session->ended_at !== null && $others->contains(
+            fn (Session $other): bool => $other->started_at->equalTo($session->ended_at)
+        );
+
+        return [
+            'can_add_session_before' => !$hasSessionImmediatelyBefore,
+            'can_add_session_after'  => $session->ended_at !== null && !$hasSessionImmediatelyAfter,
+            ...$this->beforeDefaults($session, $others),
+            ...$this->afterDefaults($session, $others),
+        ];
+    }
+
+    /**
+     * @param Collection<int, Session> $others
+     *
+     * @return array{add_before_started_at: string, add_before_ended_at: string}
+     */
+    private function beforeDefaults(Session $session, Collection $others): array
+    {
+        /** @var Carbon|null $previousEnd */
+        $previousEnd = $others
+            ->filter(fn (Session $other): bool => $other->ended_at !== null && $other->ended_at->lessThanOrEqualTo($session->started_at))
+            ->max(fn (Session $other): Carbon => $other->ended_at);
+
+        $startedAt = $previousEnd ?? $session->started_at->copy()->subHour();
+
+        return [
+            'add_before_started_at' => $this->localDateTime($startedAt),
+            'add_before_ended_at'   => $this->localDateTime($session->started_at),
+        ];
+    }
+
+    /**
+     * @param Collection<int, Session> $others
+     *
+     * @return array{add_after_started_at: string|null, add_after_ended_at: string|null}
+     */
+    private function afterDefaults(Session $session, Collection $others): array
+    {
+        if ($session->ended_at === null) {
+            return [
+                'add_after_started_at' => null,
+                'add_after_ended_at'   => null,
+            ];
+        }
+
+        /** @var Carbon|null $nextStart */
+        $nextStart = $others
+            ->filter(fn (Session $other): bool => $other->started_at->greaterThanOrEqualTo($session->ended_at))
+            ->min(fn (Session $other): Carbon => $other->started_at);
+
+        $endedAt = $nextStart ?? $session->ended_at->copy()->addHour();
+
+        return [
+            'add_after_started_at' => $this->localDateTime($session->ended_at),
+            'add_after_ended_at'   => $this->localDateTime($endedAt),
+        ];
+    }
+
+    private function localDateTime(Carbon $dateTime): string
+    {
+        return $this->dateTimeFormatter->localFormat($dateTime, DateTimeFormatter::DATETIME_FOR_MYSQL_FORMAT);
+    }
+}

--- a/resources/js/Pages/Session/Index.vue
+++ b/resources/js/Pages/Session/Index.vue
@@ -76,6 +76,18 @@
               :on-close="closeEditSessionModal"
               :on-submit="handleEditSession"
           ></edit-session-modal>
+          <add-session-modal
+              ref="addSessionModal"
+              :is-open="showAddSessionModal"
+              :title="addSessionModalTitle"
+              :initial-form="addSessionInitialForm"
+              :tasks="tasks"
+              :sprints="sprints"
+              :invoices="invoices"
+              :session-categories="sessionCategories"
+              :on-close="closeAddSessionModal"
+              :on-submit="handleAddSession"
+          ></add-session-modal>
         </template>
         <template #title> Sessions </template>
         <template #top-right-toolbar>
@@ -104,6 +116,8 @@
             :on-change-selected-session-ids="onChangeSelectedSessionIds"
             :on-split-session="openSplitSessionModal"
             :on-edit-session="openEditSessionModal"
+            :on-add-session-before="openAddSessionBefore"
+            :on-add-session-after="openAddSessionAfter"
             :highlighted-session-id="recentlyEditedSessionId"
         ></index-session-table>
 
@@ -123,6 +137,7 @@ import sprintSelect from '@/Shared/SprintSelect.vue';
 import taskSelect from '@/Shared/TaskSelect.vue';
 import splitSessionModal from '@/components/SplitSessionModal.vue';
 import editSessionModal from '@/components/EditSessionModal.vue';
+import addSessionModal from '@/components/AddSessionModal.vue';
 import modernModal from '@/components/Modal.vue';
 
 export default {
@@ -137,6 +152,9 @@ export default {
             showSplitSessionModal: false,
             sessionToEdit: null,
             showEditSessionModal: false,
+            showAddSessionModal: false,
+            addSessionModalTitle: 'Add Session',
+            addSessionInitialForm: null,
             recentlyEditedSessionId: null,
             recentlyEditedSessionTimeout: null,
         }
@@ -151,6 +169,7 @@ export default {
         taskSelect: taskSelect,
         splitSessionModal: splitSessionModal,
         editSessionModal: editSessionModal,
+        addSessionModal: addSessionModal,
         modernModal: modernModal,
     },
     props: {
@@ -158,6 +177,7 @@ export default {
         invoices: Array,
         tasks: Array,
         sprints: Array,
+        sessionCategories: Array,
         thirdPartyApplications: Array,
         page: Number,
         perPage: Number,
@@ -249,6 +269,41 @@ export default {
                 },
                 onError: () => {
                     this.$refs.editSessionModal?.resetSubmitting();
+                },
+            });
+        },
+        openAddSessionBefore(session) {
+            this.openAddSession(session, 'before');
+        },
+        openAddSessionAfter(session) {
+            this.openAddSession(session, 'after');
+        },
+        openAddSession(session, direction) {
+            this.addSessionModalTitle = direction === 'before' ? 'Add Session Before' : 'Add Session After';
+            this.addSessionInitialForm = {
+                started_at: direction === 'before' ? session.add_before_started_at : session.add_after_started_at,
+                ended_at: direction === 'before' ? session.add_before_ended_at : session.add_after_ended_at,
+                task_id: session.task_id,
+                sprint_id: session.sprint_id,
+                invoice_id: session.invoice_id,
+                session_category_id: session.session_category_id,
+                comment: null,
+                is_billable: Boolean(session.is_billable),
+            };
+            this.showAddSessionModal = true;
+        },
+        closeAddSessionModal() {
+            this.showAddSessionModal = false;
+            this.addSessionInitialForm = null;
+        },
+        handleAddSession(form) {
+            this.$inertia.post(route('session.store'), form, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    this.closeAddSessionModal();
+                },
+                onError: () => {
+                    this.$refs.addSessionModal?.resetSubmitting();
                 },
             });
         },

--- a/resources/js/components/AddSessionModal.vue
+++ b/resources/js/components/AddSessionModal.vue
@@ -1,0 +1,267 @@
+<template>
+  <modal
+    :is-open="isOpen"
+    :title="title"
+    max-width="2xl"
+    scroll-behavior="body"
+    :show-default-footer="false"
+    :confirm-loading="isSubmitting"
+    @close="handleClose"
+  >
+    <form v-if="form" class="space-y-4" @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="add-session-started-at">Started At</label>
+        <input
+          id="add-session-started-at"
+          v-model="form.started_at"
+          type="text"
+          name="started_at"
+          class="form-control"
+          placeholder="YYYY-MM-DD HH:MM:SS"
+        >
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-ended-at">Ended At</label>
+        <input
+          id="add-session-ended-at"
+          v-model="form.ended_at"
+          type="text"
+          name="ended_at"
+          class="form-control"
+          placeholder="YYYY-MM-DD HH:MM:SS"
+        >
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-task">Task</label>
+        <task-select
+          :tasks="tasks"
+          :task="form.task_id"
+          compact
+          use-teleport
+          :on-change="selectTask"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-sprint">Sprint</label>
+        <sprint-select
+          :sprints="filteredSprints"
+          :sprint="form.sprint_id"
+          compact
+          use-teleport
+          :on-change="selectSprint"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-invoice">Invoice</label>
+        <invoice-select
+          :invoices="invoices"
+          :invoice="form.invoice_id"
+          :on-change="selectInvoice"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-category">Session Category</label>
+        <session-category-select
+          :session-categories="sessionCategories"
+          v-model="form.session_category_id"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-comment">Comment</label>
+        <input
+          id="add-session-comment"
+          v-model="form.comment"
+          type="text"
+          name="comment"
+          class="form-control"
+          placeholder=""
+        >
+      </div>
+
+      <div class="form-group">
+        <label for="add-session-billable">Is Billable</label>
+        <input
+          id="add-session-billable"
+          v-model="form.is_billable"
+          type="checkbox"
+          class="form-checkbox"
+          name="is_billable"
+        >
+      </div>
+    </form>
+
+    <template #footer>
+      <div class="flex justify-end gap-3">
+        <button
+          type="button"
+          class="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="isSubmitting"
+          @click="handleClose"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="isSubmitting || !form"
+          @click="handleSubmit"
+        >
+          <i v-if="isSubmitting" class="fa fa-spinner fa-spin mr-2" aria-hidden="true"></i>
+          Add Session
+        </button>
+      </div>
+    </template>
+  </modal>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import Modal from './Modal.vue'
+import TaskSelect from '@/Shared/TaskSelect.vue'
+import SprintSelect from '@/Shared/SprintSelect.vue'
+import InvoiceSelect from '@/Shared/InvoiceSelect.vue'
+import SessionCategorySelect from '@/Shared/SessionCategorySelect.vue'
+
+const props = defineProps({
+  isOpen: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: 'Add Session',
+  },
+  initialForm: {
+    type: Object,
+    default: null,
+  },
+  tasks: {
+    type: Array,
+    default: () => [],
+  },
+  sprints: {
+    type: Array,
+    default: () => [],
+  },
+  invoices: {
+    type: Array,
+    default: () => [],
+  },
+  sessionCategories: {
+    type: Array,
+    default: () => [],
+  },
+  onClose: {
+    type: Function,
+    default: () => {},
+  },
+  onSubmit: {
+    type: Function,
+    default: () => {},
+  },
+})
+
+const emit = defineEmits(['close', 'submit'])
+
+const isSubmitting = ref(false)
+const form = ref(null)
+
+const filteredSprints = computed(() => {
+  if (!form.value?.task_id) {
+    return props.sprints
+  }
+
+  const selectedTask = props.tasks.find((task) => task.id == form.value.task_id)
+
+  if (!selectedTask?.project) {
+    return props.sprints
+  }
+
+  return props.sprints.filter((sprint) => sprintIncludesProject(sprint, selectedTask.project.id))
+})
+
+function sprintIncludesProject(sprint, projectId) {
+  if (!sprint?.projects || !Array.isArray(sprint.projects)) {
+    return false
+  }
+
+  return sprint.projects.some((project) => project.id == projectId)
+}
+
+function buildForm(initial) {
+  return {
+    started_at: initial?.started_at ?? null,
+    ended_at: initial?.ended_at ?? null,
+    task_id: initial?.task_id ?? null,
+    sprint_id: initial?.sprint_id ?? null,
+    invoice_id: initial?.invoice_id ?? null,
+    comment: initial?.comment ?? null,
+    is_billable: Boolean(initial?.is_billable),
+    session_category_id: initial?.session_category_id ?? null,
+  }
+}
+
+function selectSprint(sprintId) {
+  form.value.sprint_id = sprintId
+}
+
+function selectInvoice(invoiceId) {
+  form.value.invoice_id = invoiceId
+}
+
+function selectTask(taskId) {
+  form.value.task_id = taskId
+
+  if (taskId && form.value.sprint_id) {
+    const selectedTask = props.tasks.find((task) => task.id == taskId)
+    const selectedSprint = props.sprints.find((sprint) => sprint.id == form.value.sprint_id)
+
+    if (selectedTask?.project && selectedSprint && !sprintIncludesProject(selectedSprint, selectedTask.project.id)) {
+      form.value.sprint_id = null
+    }
+  }
+}
+
+function handleClose() {
+  if (isSubmitting.value) {
+    return
+  }
+
+  props.onClose()
+  emit('close')
+}
+
+function handleSubmit() {
+  if (!form.value || isSubmitting.value) {
+    return
+  }
+
+  isSubmitting.value = true
+  props.onSubmit({ ...form.value })
+  emit('submit', { ...form.value })
+}
+
+function resetSubmitting() {
+  isSubmitting.value = false
+}
+
+watch(() => props.isOpen, (isOpen) => {
+  if (isOpen) {
+    form.value = buildForm(props.initialForm)
+    isSubmitting.value = false
+  } else {
+    form.value = null
+    isSubmitting.value = false
+  }
+})
+
+defineExpose({
+  resetSubmitting,
+})
+</script>

--- a/resources/js/components/IndexSessionTable.vue
+++ b/resources/js/components/IndexSessionTable.vue
@@ -575,6 +575,8 @@
             'onChangeSelectedSessionIds',
             'onSplitSession',
             'onEditSession',
+            'onAddSessionBefore',
+            'onAddSessionAfter',
             'highlightedSessionId',
         ],
         components: {
@@ -757,6 +759,16 @@
                     this.onEditSession(session);
                 }
             };
+            this._onAddSessionBefore = (session) => {
+                if (this.onAddSessionBefore) {
+                    this.onAddSessionBefore(session);
+                }
+            };
+            this._onAddSessionAfter = (session) => {
+                if (this.onAddSessionAfter) {
+                    this.onAddSessionAfter(session);
+                }
+            };
             this._onConfirmDeleteSession = (session) => {
                 this.sessionToDelete = session;
             };
@@ -768,6 +780,8 @@
             events.on('continue-session', this._onContinueSession);
             events.on('split-session', this._onSplitSession);
             events.on('edit-session', this._onEditSession);
+            events.on('add-session-before', this._onAddSessionBefore);
+            events.on('add-session-after', this._onAddSessionAfter);
             events.on('confirm-delete-session', this._onConfirmDeleteSession);
         },
         beforeUnmount() {
@@ -778,6 +792,8 @@
             events.off('continue-session', this._onContinueSession);
             events.off('split-session', this._onSplitSession);
             events.off('edit-session', this._onEditSession);
+            events.off('add-session-before', this._onAddSessionBefore);
+            events.off('add-session-after', this._onAddSessionAfter);
             events.off('confirm-delete-session', this._onConfirmDeleteSession);
         },
         methods: {
@@ -949,7 +965,27 @@
                         });
                     }
                 }
-                
+
+                if (session.can_add_session_before) {
+                    actions.push({
+                        name: 'Add Session Before',
+                        event: {
+                            name: 'add-session-before',
+                            args: session
+                        }
+                    });
+                }
+
+                if (session.can_add_session_after) {
+                    actions.push({
+                        name: 'Add Session After',
+                        event: {
+                            name: 'add-session-after',
+                            args: session
+                        }
+                    });
+                }
+
                 actions.push({
                     name: 'Edit Session',
                     event: {

--- a/tests/Feature/Session/AddAdjacentSessionTest.php
+++ b/tests/Feature/Session/AddAdjacentSessionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\Session;
+use App\Support\DateTimeFormatter;
+
+/**
+ * @return \Illuminate\Support\Collection<int, array<string, mixed>>
+ */
+function sessionsFromIndex(): \Illuminate\Support\Collection
+{
+    $response = test()->get(route('session.index', ['per-page' => 100]));
+
+    $response->assertSuccessful();
+
+    return collect($response->props('days'))
+        ->flatMap(fn ($day) => $day['sessions'])
+        ->keyBy('id');
+}
+
+beforeEach(function () {
+    $this->usingTestDisplayTimeZone('UTC');
+    $this->actingAsUser();
+});
+
+it('hides add-before and add-after when a session is touching on that side', function () {
+    $earlier = Session::factory()->create([
+        'started_at' => '2023-01-01 09:00:00',
+        'ended_at'   => '2023-01-01 10:00:00',
+    ]);
+
+    $later = Session::factory()->create([
+        'started_at' => '2023-01-01 10:00:00',
+        'ended_at'   => '2023-01-01 11:00:00',
+    ]);
+
+    $sessions = sessionsFromIndex();
+
+    expect($sessions[$earlier->id]['can_add_session_before'])->toBeTrue();
+    expect($sessions[$earlier->id]['can_add_session_after'])->toBeFalse();
+
+    expect($sessions[$later->id]['can_add_session_before'])->toBeFalse();
+    expect($sessions[$later->id]['can_add_session_after'])->toBeTrue();
+});
+
+it('allows adding a session in the gap between two sessions and fills the gap by default', function () {
+    $earlier = Session::factory()->create([
+        'started_at' => '2023-01-01 09:00:00',
+        'ended_at'   => '2023-01-01 10:00:00',
+    ]);
+
+    $later = Session::factory()->create([
+        'started_at' => '2023-01-01 11:00:00',
+        'ended_at'   => '2023-01-01 12:00:00',
+    ]);
+
+    $sessions = sessionsFromIndex();
+
+    expect($sessions[$earlier->id]['can_add_session_after'])->toBeTrue();
+    expect($sessions[$earlier->id]['add_after_started_at'])->toBe('2023-01-01 10:00:00');
+    expect($sessions[$earlier->id]['add_after_ended_at'])->toBe('2023-01-01 11:00:00');
+
+    expect($sessions[$later->id]['can_add_session_before'])->toBeTrue();
+    expect($sessions[$later->id]['add_before_started_at'])->toBe('2023-01-01 10:00:00');
+    expect($sessions[$later->id]['add_before_ended_at'])->toBe('2023-01-01 11:00:00');
+});
+
+it('defaults to a one hour duration when there is no neighbouring session', function () {
+    $session = Session::factory()->create([
+        'started_at' => '2023-01-01 09:00:00',
+        'ended_at'   => '2023-01-01 10:00:00',
+    ]);
+
+    $sessions = sessionsFromIndex();
+
+    expect($sessions[$session->id]['can_add_session_before'])->toBeTrue();
+    expect($sessions[$session->id]['add_before_started_at'])->toBe('2023-01-01 08:00:00');
+    expect($sessions[$session->id]['add_before_ended_at'])->toBe('2023-01-01 09:00:00');
+
+    expect($sessions[$session->id]['can_add_session_after'])->toBeTrue();
+    expect($sessions[$session->id]['add_after_started_at'])->toBe('2023-01-01 10:00:00');
+    expect($sessions[$session->id]['add_after_ended_at'])->toBe('2023-01-01 11:00:00');
+});
+
+it('allows a session to be added before a running session but not after', function () {
+    $session = Session::factory()->running()->create([
+        'started_at' => '2023-01-01 09:00:00',
+    ]);
+
+    $sessions = sessionsFromIndex();
+
+    expect($sessions[$session->id]['can_add_session_before'])->toBeTrue();
+    expect($sessions[$session->id]['add_before_started_at'])->toBe('2023-01-01 08:00:00');
+    expect($sessions[$session->id]['add_before_ended_at'])->toBe('2023-01-01 09:00:00');
+
+    expect($sessions[$session->id]['can_add_session_after'])->toBeFalse();
+    expect($sessions[$session->id]['add_after_started_at'])->toBeNull();
+    expect($sessions[$session->id]['add_after_ended_at'])->toBeNull();
+});
+
+it('creates a session immediately before an existing session via the store endpoint', function () {
+    $existing = Session::factory()->create([
+        'started_at' => '2023-01-01 10:00:00',
+        'ended_at'   => '2023-01-01 11:00:00',
+    ]);
+
+    $before = sessionsFromIndex()[$existing->id];
+
+    $this->post(route('session.store'), [
+        'started_at' => $before['add_before_started_at'],
+        'ended_at'   => $before['add_before_ended_at'],
+    ])->assertRedirect(route('session.index'));
+
+    $this->assertDatabaseHas('sessions', [
+        'started_at' => app(DateTimeFormatter::class)->utcFormat('2023-01-01 09:00:00'),
+        'ended_at'   => app(DateTimeFormatter::class)->utcFormat('2023-01-01 10:00:00'),
+    ]);
+
+    // The existing session now has a session touching it, so add-before is hidden.
+    expect(sessionsFromIndex()[$existing->id]['can_add_session_before'])->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Adds **Add Session Before** and **Add Session After** actions to each session in the Sessions list, for sessions that don't already have a session immediately before/after them.

- Each action appears only when no existing session is **touching** that side (contiguous adjacency, since sessions are ordered purely by time).
- Selecting one opens a pre-filled create-session modal that **fills the gap** to the neighbouring session, or defaults to a **one-hour** block when there's nothing on that side. Context (task, sprint, invoice, category, billable) is inherited from the reference session and can be adjusted before saving.
- Running sessions can have a session added *before* them, but not after.

## Implementation

- `SessionAdjacencyResolver` (new service) computes `can_add_session_before`/`can_add_session_after` and the default `add_before_*` / `add_after_*` times for every session on the page. Computed over the full page collection so it works across day boundaries.
- `SessionController@index` attaches this data to each session and now also passes `sessionCategories` for the modal.
- New `AddSessionModal.vue` (props-driven, mirrors the existing Edit Session modal). New sessions are saved through the existing `session.store` endpoint — no new route.
- Actions are gated in `IndexSessionTable.vue`; locked days already hide the actions menu, so those are covered.

## Testing

- New `tests/Feature/Session/AddAdjacentSessionTest.php` (5 tests): contiguous hiding, gap-filling defaults, one-hour fallback, running-session behaviour, and end-to-end creation.
- Full session suite (65 tests) passes; `npm run build` succeeds.

## Note

Adjacency is O(n²) over the page — negligible at the default 100/page, worth revisiting only if the 1000/page size sees heavy use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)